### PR TITLE
Add reservation management and event cancellation support

### DIFF
--- a/backend/src/main/java/com/soen345/ticketreserve/controller/EventController.java
+++ b/backend/src/main/java/com/soen345/ticketreserve/controller/EventController.java
@@ -79,6 +79,11 @@ public class EventController {
         return ResponseEntity.ok(toResponse(updatedEvent));
     }
 
+    @PutMapping("/cancel/{id}")
+    public ResponseEntity<EventResponse> cancelEvent(@PathVariable Long id) {
+        return ResponseEntity.ok(toResponse(eventService.cancelEvent(id)));
+    }
+
     @DeleteMapping("/delete/{id}")
     public ResponseEntity<Void> deleteEvent(@PathVariable("id") Long id) {
         eventService.deleteEvent(id);
@@ -95,7 +100,8 @@ public class EventController {
                 event.getLocation(),
                 event.getEventCapacity(),
                 eventService.getRemainingSpots(event),
-                event.getCategory()
+                event.getCategory(),
+                eventService.getStatus(event)
         );
     }
 }

--- a/backend/src/main/java/com/soen345/ticketreserve/controller/ReservationController.java
+++ b/backend/src/main/java/com/soen345/ticketreserve/controller/ReservationController.java
@@ -7,6 +7,8 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/reservations")
 @CrossOrigin(origins = "*")
@@ -22,5 +24,16 @@ public class ReservationController {
     public ResponseEntity<ReservationResponse> createReservation(@Valid @RequestBody ReservationRequest request) {
         ReservationResponse response = reservationService.createReservation(request);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<ReservationResponse>> getReservationsForUser(@PathVariable Long userId) {
+        return ResponseEntity.ok(reservationService.getReservationsForUser(userId));
+    }
+
+    @DeleteMapping("/{reservationId}")
+    public ResponseEntity<ReservationResponse> cancelReservation(@PathVariable Long reservationId,
+                                                                 @RequestParam Long userId) {
+        return ResponseEntity.ok(reservationService.cancelReservation(userId, reservationId));
     }
 }

--- a/backend/src/main/java/com/soen345/ticketreserve/dto/EventResponse.java
+++ b/backend/src/main/java/com/soen345/ticketreserve/dto/EventResponse.java
@@ -12,11 +12,12 @@ public class EventResponse {
     private int eventCapacity;
     private int remainingSpots;
     private String category;
+    private String status;
 
     public EventResponse() {}
 
     public EventResponse(Long eventId, Long organizerId, String title, String description, LocalDate date,
-                         String location, int eventCapacity, int remainingSpots, String category) {
+                         String location, int eventCapacity, int remainingSpots, String category, String status) {
         this.eventId = eventId;
         this.organizerId = organizerId;
         this.title = title;
@@ -26,6 +27,7 @@ public class EventResponse {
         this.eventCapacity = eventCapacity;
         this.remainingSpots = remainingSpots;
         this.category = category;
+        this.status = status;
     }
 
     public Long getEventId() {
@@ -98,5 +100,13 @@ public class EventResponse {
 
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
     }
 }

--- a/backend/src/main/java/com/soen345/ticketreserve/dto/ReservationResponse.java
+++ b/backend/src/main/java/com/soen345/ticketreserve/dto/ReservationResponse.java
@@ -1,5 +1,7 @@
 package com.soen345.ticketreserve.dto;
 
+import java.time.LocalDate;
+
 public class ReservationResponse {
 
     private Long reservationId;
@@ -7,6 +9,10 @@ public class ReservationResponse {
     private String customerEmail;
     private String eventName;
     private int quantity;
+    private Long eventId;
+    private LocalDate eventDate;
+    private String eventLocation;
+    private String eventStatus;
 
     public ReservationResponse() {
     }
@@ -17,6 +23,20 @@ public class ReservationResponse {
         this.customerEmail = customerEmail;
         this.eventName = eventName;
         this.quantity = quantity;
+    }
+
+    public ReservationResponse(Long reservationId, String message, String customerEmail, String eventName,
+                               int quantity, Long eventId, LocalDate eventDate, String eventLocation,
+                               String eventStatus) {
+        this.reservationId = reservationId;
+        this.message = message;
+        this.customerEmail = customerEmail;
+        this.eventName = eventName;
+        this.quantity = quantity;
+        this.eventId = eventId;
+        this.eventDate = eventDate;
+        this.eventLocation = eventLocation;
+        this.eventStatus = eventStatus;
     }
 
     public Long getReservationId() {
@@ -39,6 +59,22 @@ public class ReservationResponse {
         return quantity;
     }
 
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public LocalDate getEventDate() {
+        return eventDate;
+    }
+
+    public String getEventLocation() {
+        return eventLocation;
+    }
+
+    public String getEventStatus() {
+        return eventStatus;
+    }
+
     public void setReservationId(Long reservationId) {
         this.reservationId = reservationId;
     }
@@ -57,5 +93,21 @@ public class ReservationResponse {
 
     public void setQuantity(int quantity) {
         this.quantity = quantity;
+    }
+
+    public void setEventId(Long eventId) {
+        this.eventId = eventId;
+    }
+
+    public void setEventDate(LocalDate eventDate) {
+        this.eventDate = eventDate;
+    }
+
+    public void setEventLocation(String eventLocation) {
+        this.eventLocation = eventLocation;
+    }
+
+    public void setEventStatus(String eventStatus) {
+        this.eventStatus = eventStatus;
     }
 }

--- a/backend/src/main/java/com/soen345/ticketreserve/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/soen345/ticketreserve/repository/ReservationRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 	List<Reservation> findByUser_Id(Long userId);
+    Optional<Reservation> findByIdAndUser_Id(Long reservationId, Long userId);
+    void deleteByEvent_EventId(Long eventId);
 
     @Query("select coalesce(sum(r.quantity), 0) from Reservation r where r.event.eventId = :eventId")
     int sumQuantityByEventId(@Param("eventId") Long eventId);

--- a/backend/src/main/java/com/soen345/ticketreserve/service/EventService.java
+++ b/backend/src/main/java/com/soen345/ticketreserve/service/EventService.java
@@ -6,9 +6,13 @@ import com.soen345.ticketreserve.repository.EventRepository;
 import com.soen345.ticketreserve.exception.BadRequestException;
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class EventService {
+    public static final String STATUS_ACTIVE = "ACTIVE";
+    public static final String STATUS_CANCELLED = "CANCELLED";
+
     private final EventRepository eventRepository;
     private final ReservationRepository reservationRepository;
 
@@ -18,7 +22,10 @@ public class EventService {
     }
 
     public List<Event> getAllEvents() {
-        return eventRepository.findAll();
+        return eventRepository.findAll()
+                .stream()
+                .filter(event -> !isCancelled(event))
+                .toList();
     }
 
     public List<Event> getEventsByOrganizerId(Long organizerId) {
@@ -50,6 +57,7 @@ public class EventService {
         if (event.getEventCapacity() <= 0) {
             throw new BadRequestException("Event capacity must be greater than 0");
         }
+        event.setStatus(STATUS_ACTIVE);
         return eventRepository.save(event);
     }
 
@@ -76,10 +84,18 @@ public class EventService {
         return eventRepository.save(existing);
     }
 
+    public Event cancelEvent(Long eventId) {
+        Event existing = getEventById(eventId);
+        existing.setStatus(STATUS_CANCELLED);
+        return eventRepository.save(existing);
+    }
+
+    @Transactional
     public void deleteEvent(Long eventId) {
         if (!eventRepository.existsById(eventId)) {
             throw new BadRequestException("Event not found with id: " + eventId);
         }
+        reservationRepository.deleteByEvent_EventId(eventId);
         eventRepository.deleteById(eventId);
     }
 
@@ -89,5 +105,16 @@ public class EventService {
         }
         int reservedSpots = reservationRepository.sumQuantityByEventId(event.getEventId());
         return Math.max(event.getEventCapacity() - reservedSpots, 0);
+    }
+
+    public String getStatus(Event event) {
+        if (event == null || event.getStatus() == null || event.getStatus().trim().isEmpty()) {
+            return STATUS_ACTIVE;
+        }
+        return event.getStatus();
+    }
+
+    private boolean isCancelled(Event event) {
+        return STATUS_CANCELLED.equalsIgnoreCase(getStatus(event));
     }
 }

--- a/backend/src/main/java/com/soen345/ticketreserve/service/ReservationService.java
+++ b/backend/src/main/java/com/soen345/ticketreserve/service/ReservationService.java
@@ -3,14 +3,15 @@ package com.soen345.ticketreserve.service;
 import com.soen345.ticketreserve.dto.ReservationRequest;
 import com.soen345.ticketreserve.dto.ReservationResponse;
 import com.soen345.ticketreserve.exception.BadRequestException;
+import com.soen345.ticketreserve.model.Event;
 import com.soen345.ticketreserve.model.Reservation;
 import com.soen345.ticketreserve.model.User;
-import com.soen345.ticketreserve.model.Event;
+import com.soen345.ticketreserve.repository.EventRepository;
 import com.soen345.ticketreserve.repository.ReservationRepository;
 import com.soen345.ticketreserve.repository.UserRepository;
-import com.soen345.ticketreserve.repository.EventRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -28,11 +29,12 @@ public class ReservationService {
         this.eventRepository = eventRepository;
     }
 
-        public ReservationResponse createReservation(ReservationRequest request) {
-        User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + request.getUserId()));
-        Event event = eventRepository.findById(request.getEventId())
-                .orElseThrow(() -> new IllegalArgumentException("Event not found with ID: " + request.getEventId()));
+    public ReservationResponse createReservation(ReservationRequest request) {
+        User user = findUser(request.getUserId());
+        Event event = findEvent(request.getEventId());
+        if (EventService.STATUS_CANCELLED.equalsIgnoreCase(event.getStatus())) {
+            throw new BadRequestException("This event has been cancelled.");
+        }
         if (request.getQuantity() <= 0) {
             throw new BadRequestException("Quantity must be at least 1");
         }
@@ -58,19 +60,58 @@ public class ReservationService {
             savedReservation.getId()
         );
 
-        return new ReservationResponse(
-            savedReservation.getId(),
-            "Reservation created successfully and email confirmation sent.",
-            user.getEmail(),
-            event.getTitle(),
-            savedReservation.getQuantity()
-        );
+        return toReservationResponse(savedReservation, "Reservation created successfully and email confirmation sent.");
     }
 
-    public List<Event> getEventsForUser(Long userId) {
+    public List<ReservationResponse> getReservationsForUser(Long userId) {
+        findUser(userId);
+
         return reservationRepository.findByUser_Id(userId)
                 .stream()
-                .map(Reservation::getEvent)
+                .sorted(Comparator
+                        .comparing((Reservation reservation) -> reservation.getEvent().getEventDate(),
+                                Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(Reservation::getId, Comparator.nullsLast(Comparator.reverseOrder())))
+                .map(reservation -> toReservationResponse(reservation, null))
                 .toList();
+    }
+
+    public ReservationResponse cancelReservation(Long userId, Long reservationId) {
+        findUser(userId);
+
+        Reservation reservation = reservationRepository.findByIdAndUser_Id(reservationId, userId)
+                .orElseThrow(() -> new BadRequestException("Reservation not found for this user."));
+
+        ReservationResponse response = toReservationResponse(reservation, "Reservation canceled successfully.");
+        reservationRepository.delete(reservation);
+        return response;
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException("User not found with ID: " + userId));
+    }
+
+    private Event findEvent(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new BadRequestException("Event not found with ID: " + eventId));
+    }
+
+    private ReservationResponse toReservationResponse(Reservation reservation, String message) {
+        Event event = reservation.getEvent();
+        User user = reservation.getUser();
+        return new ReservationResponse(
+                reservation.getId(),
+                message,
+                user.getEmail(),
+                event.getTitle(),
+                reservation.getQuantity(),
+                event.getEventId(),
+                event.getEventDate(),
+                event.getLocation(),
+                event.getStatus() == null || event.getStatus().trim().isEmpty()
+                        ? EventService.STATUS_ACTIVE
+                        : event.getStatus()
+        );
     }
 }

--- a/backend/src/test/java/com/soen345/ticketreserve/controller/EventControllerTest.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/controller/EventControllerTest.java
@@ -5,6 +5,7 @@ import com.soen345.ticketreserve.model.Event;
 import com.soen345.ticketreserve.model.User;
 import com.soen345.ticketreserve.service.EventService;
 import com.soen345.ticketreserve.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -38,6 +39,17 @@ class EventControllerTest {
         @MockitoBean
         private UserService userService;
 
+    @BeforeEach
+    void setUp() {
+        when(eventService.getStatus(any(Event.class))).thenAnswer(invocation -> {
+            Event event = invocation.getArgument(0);
+            if (event.getStatus() == null || event.getStatus().trim().isEmpty()) {
+                return EventService.STATUS_ACTIVE;
+            }
+            return event.getStatus();
+        });
+    }
+
     @Test
     void shouldReturnAllEvents() throws Exception {
         Event eventOne = new Event();
@@ -48,6 +60,7 @@ class EventControllerTest {
         eventOne.setLocation("Montreal");
         eventOne.setEventCapacity(120);
         eventOne.setCategory("Tech");
+        eventOne.setStatus("ACTIVE");
 
         Event eventTwo = new Event();
         eventTwo.setEventId(2L);
@@ -57,6 +70,7 @@ class EventControllerTest {
         eventTwo.setLocation("Toronto");
         eventTwo.setEventCapacity(350);
         eventTwo.setCategory("Music");
+        eventTwo.setStatus("ACTIVE");
 
         when(eventService.getAllEvents()).thenReturn(List.of(eventOne, eventTwo));
         when(eventService.getRemainingSpots(eventOne)).thenReturn(95);
@@ -69,11 +83,13 @@ class EventControllerTest {
                 .andExpect(jsonPath("$[0].date").value("2026-04-10"))
                 .andExpect(jsonPath("$[0].remainingSpots").value(95))
                 .andExpect(jsonPath("$[0].category").value("Tech"))
+                .andExpect(jsonPath("$[0].status").value("ACTIVE"))
                 .andExpect(jsonPath("$[1].eventId").value(2))
                 .andExpect(jsonPath("$[1].title").value("Summer Concert"))
                 .andExpect(jsonPath("$[1].date").value("2026-08-21"))
                 .andExpect(jsonPath("$[1].remainingSpots").value(320))
-                .andExpect(jsonPath("$[1].category").value("Music"));
+                .andExpect(jsonPath("$[1].category").value("Music"))
+                .andExpect(jsonPath("$[1].status").value("ACTIVE"));
     }
 
     @Test
@@ -90,6 +106,7 @@ class EventControllerTest {
         event.setLocation("Montreal");
         event.setEventCapacity(40);
         event.setCategory("Workshop");
+        event.setStatus("ACTIVE");
 
         when(eventService.getEventById(9L)).thenReturn(event);
         when(eventService.getRemainingSpots(event)).thenReturn(27);
@@ -99,7 +116,8 @@ class EventControllerTest {
                 .andExpect(jsonPath("$.eventId").value(9))
                 .andExpect(jsonPath("$.organizerId").value(4))
                 .andExpect(jsonPath("$.title").value("Design Jam"))
-                .andExpect(jsonPath("$.remainingSpots").value(27));
+                .andExpect(jsonPath("$.remainingSpots").value(27))
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
     }
 
     @Test
@@ -122,6 +140,7 @@ class EventControllerTest {
         created.setLocation("Montreal");
         created.setCategory("General");
         created.setEventCapacity(120);
+        created.setStatus("ACTIVE");
 
         User organizer = new User();
         organizer.setId(1L);
@@ -151,7 +170,8 @@ class EventControllerTest {
                 .andExpect(jsonPath("$.location").value("Montreal"))
                 .andExpect(jsonPath("$.category").value("General"))
                 .andExpect(jsonPath("$.remainingSpots").value(120))
-                .andExpect(jsonPath("$.eventCapacity").value(120));
+                .andExpect(jsonPath("$.eventCapacity").value(120))
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
     }
 
     @Test
@@ -188,6 +208,27 @@ class EventControllerTest {
     }
 
     @Test
+    void shouldCancelEvent() throws Exception {
+        Event cancelled = new Event();
+        cancelled.setEventId(11L);
+        cancelled.setTitle("Cancelled Event");
+        cancelled.setDescription("Cancelled desc");
+        cancelled.setEventDate(LocalDate.of(2026, 8, 1));
+        cancelled.setLocation("Montreal");
+        cancelled.setCategory("General");
+        cancelled.setEventCapacity(50);
+        cancelled.setStatus("CANCELLED");
+
+        when(eventService.cancelEvent(11L)).thenReturn(cancelled);
+        when(eventService.getRemainingSpots(cancelled)).thenReturn(25);
+
+        mockMvc.perform(put("/api/events/cancel/11"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventId").value(11))
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+    }
+
+    @Test
     void shouldReturnBadRequestWhenDeleteFails() throws Exception {
         doThrow(new BadRequestException("Event not found with id: 999"))
                 .when(eventService).deleteEvent(999L);
@@ -211,6 +252,7 @@ class EventControllerTest {
         e1.setEventCapacity(100);
         e1.setCategory("Social");
         e1.setOrganizer(organizer);
+        e1.setStatus("ACTIVE");
 
         Event e2 = new Event();
         e2.setEventId(2L);
@@ -221,6 +263,7 @@ class EventControllerTest {
         e2.setEventCapacity(30);
         e2.setCategory("Tech");
         e2.setOrganizer(organizer);
+        e2.setStatus("CANCELLED");
 
         when(eventService.getEventsByOrganizerId(7L)).thenReturn(List.of(e1, e2));
         when(eventService.getRemainingSpots(e1)).thenReturn(80);
@@ -232,10 +275,12 @@ class EventControllerTest {
                 .andExpect(jsonPath("$[0].title").value("Host Gala"))
                 .andExpect(jsonPath("$[0].organizerId").value(7))
                 .andExpect(jsonPath("$[0].remainingSpots").value(80))
+                .andExpect(jsonPath("$[0].status").value("ACTIVE"))
                 .andExpect(jsonPath("$[1].eventId").value(2))
                 .andExpect(jsonPath("$[1].title").value("Host Workshop"))
                 .andExpect(jsonPath("$[1].organizerId").value(7))
-                .andExpect(jsonPath("$[1].remainingSpots").value(12));
+                .andExpect(jsonPath("$[1].remainingSpots").value(12))
+                .andExpect(jsonPath("$[1].status").value("CANCELLED"));
     }
 
     @Test
@@ -257,6 +302,7 @@ class EventControllerTest {
         updated.setLocation("Ottawa");
         updated.setCategory("General");
         updated.setEventCapacity(80);
+        updated.setStatus("ACTIVE");
 
         when(eventService.updateEvent(any(Long.class), any(Event.class))).thenReturn(updated);
         when(eventService.getRemainingSpots(updated)).thenReturn(80);
@@ -278,7 +324,8 @@ class EventControllerTest {
                 .andExpect(jsonPath("$.title").value("Updated Meetup"))
                 .andExpect(jsonPath("$.location").value("Ottawa"))
                 .andExpect(jsonPath("$.remainingSpots").value(80))
-                .andExpect(jsonPath("$.eventCapacity").value(80));
+                .andExpect(jsonPath("$.eventCapacity").value(80))
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
     }
 
     @Test

--- a/backend/src/test/java/com/soen345/ticketreserve/controller/ReservationControllerTest.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/controller/ReservationControllerTest.java
@@ -9,11 +9,16 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -63,5 +68,53 @@ class ReservationControllerTest {
                 && request.getEventId().equals(2L)
                 && request.getQuantity() == 2
         ));
+    }
+
+    @Test
+    void shouldReturnReservationsForUser() throws Exception {
+        List<ReservationResponse> reservations = List.of(
+                new ReservationResponse(4L, null, "test@example.com", "Movie Night", 2,
+                        9L, LocalDate.of(2026, 5, 1), "Montreal", "ACTIVE"),
+                new ReservationResponse(5L, null, "test@example.com", "Tech Talk", 1,
+                        10L, LocalDate.of(2026, 5, 10), "Toronto", "CANCELLED")
+        );
+
+        when(reservationService.getReservationsForUser(1L)).thenReturn(reservations);
+
+        mockMvc.perform(get("/api/reservations/user/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].reservationId").value(4))
+                .andExpect(jsonPath("$[0].eventName").value("Movie Night"))
+                .andExpect(jsonPath("$[0].eventDate").value("2026-05-01"))
+                .andExpect(jsonPath("$[0].eventLocation").value("Montreal"))
+                .andExpect(jsonPath("$[0].eventStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$[1].reservationId").value(5));
+
+        verify(reservationService).getReservationsForUser(1L);
+    }
+
+    @Test
+    void shouldCancelReservation() throws Exception {
+        ReservationResponse response = new ReservationResponse(
+                4L,
+                "Reservation canceled successfully.",
+                "test@example.com",
+                "Movie Night",
+                2,
+                9L,
+                LocalDate.of(2026, 5, 1),
+                "Montreal",
+                "CANCELLED"
+        );
+
+        when(reservationService.cancelReservation(1L, 4L)).thenReturn(response);
+
+        mockMvc.perform(delete("/api/reservations/4")
+                        .param("userId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reservationId").value(4))
+                .andExpect(jsonPath("$.message").value("Reservation canceled successfully."));
+
+        verify(reservationService).cancelReservation(1L, 4L);
     }
 }

--- a/backend/src/test/java/com/soen345/ticketreserve/dtoTest/EventResponseTest.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/dtoTest/EventResponseTest.java
@@ -21,6 +21,7 @@ public class EventResponseTest {
         eventResponse.setEventCapacity(100);
         eventResponse.setRemainingSpots(72);
         eventResponse.setCategory("Tech");
+        eventResponse.setStatus("ACTIVE");
 
         assertEquals(1L, eventResponse.getEventId());
         assertEquals("Spring Meetup", eventResponse.getTitle());
@@ -30,6 +31,7 @@ public class EventResponseTest {
         assertEquals(100, eventResponse.getEventCapacity());
         assertEquals(72, eventResponse.getRemainingSpots());
         assertEquals("Tech", eventResponse.getCategory());
+        assertEquals("ACTIVE", eventResponse.getStatus());
     }
 
     @Test
@@ -37,7 +39,7 @@ public class EventResponseTest {
         EventResponse r = new EventResponse(
                 5L, 10L, "Concert", "Live music",
                 LocalDate.of(2026, 6, 15),
-                "Toronto", 200, 165, "Music");
+                "Toronto", 200, 165, "Music", "ACTIVE");
 
         assertEquals(5L, r.getEventId());
         assertEquals(10L, r.getOrganizerId());
@@ -48,6 +50,7 @@ public class EventResponseTest {
         assertEquals(200, r.getEventCapacity());
         assertEquals(165, r.getRemainingSpots());
         assertEquals("Music", r.getCategory());
+        assertEquals("ACTIVE", r.getStatus());
     }
 
     @Test
@@ -78,7 +81,7 @@ public class EventResponseTest {
     @Test
     void testOrganizerIdCanBeNull() {
         EventResponse r = new EventResponse(1L, null, "Title", "Desc",
-                LocalDate.of(2026, 1, 1), "Montreal", 50, 50, "General");
+                LocalDate.of(2026, 1, 1), "Montreal", 50, 50, "General", "ACTIVE");
         assertNull(r.getOrganizerId());
     }
 }

--- a/backend/src/test/java/com/soen345/ticketreserve/dtoTest/ReservationResponseTest.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/dtoTest/ReservationResponseTest.java
@@ -3,6 +3,8 @@ package com.soen345.ticketreserve.dtoTest;
 import com.soen345.ticketreserve.dto.ReservationResponse;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ReservationResponseTest {
@@ -16,12 +18,20 @@ class ReservationResponseTest {
         response.setCustomerEmail("test@example.com");
         response.setEventName("Movie Night");
         response.setQuantity(2);
+        response.setEventId(9L);
+        response.setEventDate(LocalDate.of(2026, 5, 1));
+        response.setEventLocation("Montreal");
+        response.setEventStatus("ACTIVE");
 
         assertEquals(1L, response.getReservationId());
         assertEquals("Reservation created successfully and email confirmation sent.", response.getMessage());
         assertEquals("test@example.com", response.getCustomerEmail());
         assertEquals("Movie Night", response.getEventName());
         assertEquals(2, response.getQuantity());
+        assertEquals(9L, response.getEventId());
+        assertEquals(LocalDate.of(2026, 5, 1), response.getEventDate());
+        assertEquals("Montreal", response.getEventLocation());
+        assertEquals("ACTIVE", response.getEventStatus());
     }
 
     @Test
@@ -39,5 +49,25 @@ class ReservationResponseTest {
         assertEquals("test@example.com", response.getCustomerEmail());
         assertEquals("Movie Night", response.getEventName());
         assertEquals(2, response.getQuantity());
+    }
+
+    @Test
+    void shouldCreateReservationResponseWithReservationDetails() {
+        ReservationResponse response = new ReservationResponse(
+                1L,
+                "Reservation created successfully and email confirmation sent.",
+                "test@example.com",
+                "Movie Night",
+                2,
+                9L,
+                LocalDate.of(2026, 5, 1),
+                "Montreal",
+                "CANCELLED"
+        );
+
+        assertEquals(9L, response.getEventId());
+        assertEquals(LocalDate.of(2026, 5, 1), response.getEventDate());
+        assertEquals("Montreal", response.getEventLocation());
+        assertEquals("CANCELLED", response.getEventStatus());
     }
 }

--- a/backend/src/test/java/com/soen345/ticketreserve/service/EventServiceTest.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/service/EventServiceTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +48,7 @@ class EventServiceTest {
         Event result = eventService.createEvent(event);
 
         assertEquals("Spring Meetup", result.getTitle());
+        assertEquals(EventService.STATUS_ACTIVE, event.getStatus());
         verify(eventRepository).save(event);
     }
 
@@ -113,7 +115,19 @@ class EventServiceTest {
 
         eventService.deleteEvent(5L);
 
+        verify(reservationRepository).deleteByEvent_EventId(5L);
         verify(eventRepository).deleteById(5L);
+    }
+
+    @Test
+    void shouldDeleteReservationsBeforeDeletingEvent() {
+        when(eventRepository.existsById(10L)).thenReturn(true);
+
+        eventService.deleteEvent(10L);
+
+        var inOrder = inOrder(reservationRepository, eventRepository);
+        inOrder.verify(reservationRepository).deleteByEvent_EventId(10L);
+        inOrder.verify(eventRepository).deleteById(10L);
     }
 
     @Test
@@ -129,12 +143,14 @@ class EventServiceTest {
         event1.setEventId(1L);
         Event event2 = validEvent();
         event2.setEventId(2L);
+        event2.setStatus(EventService.STATUS_CANCELLED);
 
         when(eventRepository.findAll()).thenReturn(java.util.List.of(event1, event2));
 
         java.util.List<Event> result = eventService.getAllEvents();
 
-        assertEquals(2, result.size());
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getEventId());
         verify(eventRepository).findAll();
     }
 
@@ -200,6 +216,19 @@ class EventServiceTest {
         assertEquals("Updated Title", result.getTitle());
         assertEquals("Toronto", result.getLocation());
         assertEquals(200, result.getEventCapacity());
+        verify(eventRepository).save(existing);
+    }
+
+    @Test
+    void shouldCancelEventWhenFound() {
+        Event existing = validEvent();
+        existing.setEventId(10L);
+        when(eventRepository.findById(10L)).thenReturn(Optional.of(existing));
+        when(eventRepository.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Event result = eventService.cancelEvent(10L);
+
+        assertEquals(EventService.STATUS_CANCELLED, result.getStatus());
         verify(eventRepository).save(existing);
     }
 

--- a/backend/src/test/java/com/soen345/ticketreserve/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/service/ReservationServiceTest.java
@@ -3,13 +3,16 @@ package com.soen345.ticketreserve.service;
 import com.soen345.ticketreserve.dto.ReservationRequest;
 import com.soen345.ticketreserve.dto.ReservationResponse;
 import com.soen345.ticketreserve.exception.BadRequestException;
+import com.soen345.ticketreserve.model.Event;
 import com.soen345.ticketreserve.model.Reservation;
+import com.soen345.ticketreserve.model.User;
+import com.soen345.ticketreserve.repository.EventRepository;
 import com.soen345.ticketreserve.repository.ReservationRepository;
 import com.soen345.ticketreserve.repository.UserRepository;
-import com.soen345.ticketreserve.repository.EventRepository;
-import com.soen345.ticketreserve.model.User;
-import com.soen345.ticketreserve.model.Event;
+
+import java.time.LocalDate;
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +54,9 @@ class ReservationServiceTest {
         event.setEventId(eventId);
         event.setTitle("Movie Night");
         event.setEventCapacity(10);
+        event.setEventDate(LocalDate.of(2026, 5, 1));
+        event.setLocation("Montreal");
+        event.setStatus(EventService.STATUS_ACTIVE);
 
         Reservation savedReservation = new Reservation(
             user,
@@ -71,6 +77,10 @@ class ReservationServiceTest {
         assertEquals("test@example.com", response.getCustomerEmail());
         assertEquals("Movie Night", response.getEventName());
         assertEquals(2, response.getQuantity());
+        assertEquals(eventId, response.getEventId());
+        assertEquals(LocalDate.of(2026, 5, 1), response.getEventDate());
+        assertEquals("Montreal", response.getEventLocation());
+        assertEquals(EventService.STATUS_ACTIVE, response.getEventStatus());
 
         verify(userRepository, times(1)).findById(userId);
         verify(eventRepository, times(1)).findById(eventId);
@@ -85,30 +95,43 @@ class ReservationServiceTest {
         }
 
     @Test
-    void shouldReturnAllEventsAssociatedWithUser() {
+    void shouldReturnAllReservationsAssociatedWithUser() {
         Long userId = 10L;
 
         User user = new User();
         user.setId(userId);
+        user.setEmail("test@example.com");
 
         Event event1 = new Event();
         event1.setEventId(1L);
         event1.setTitle("Movie Night");
+        event1.setEventDate(LocalDate.of(2026, 5, 20));
+        event1.setLocation("Montreal");
+        event1.setStatus(EventService.STATUS_CANCELLED);
 
         Event event2 = new Event();
         event2.setEventId(2L);
         event2.setTitle("Tech Talk");
+        event2.setEventDate(LocalDate.of(2026, 5, 10));
+        event2.setLocation("Toronto");
+        event2.setStatus(EventService.STATUS_ACTIVE);
 
         Reservation reservation1 = new Reservation(user, event1, 1);
+        reservation1.setId(1L);
         Reservation reservation2 = new Reservation(user, event2, 1);
+        reservation2.setId(2L);
 
+        when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
         when(reservationRepository.findByUser_Id(userId)).thenReturn(List.of(reservation1, reservation2));
 
-        List<Event> events = reservationService.getEventsForUser(userId);
+        List<ReservationResponse> reservations = reservationService.getReservationsForUser(userId);
 
-        assertEquals(2, events.size());
-        assertEquals("Movie Night", events.get(0).getTitle());
-        assertEquals("Tech Talk", events.get(1).getTitle());
+        assertEquals(2, reservations.size());
+        assertEquals("Tech Talk", reservations.get(0).getEventName());
+        assertEquals("Movie Night", reservations.get(1).getEventName());
+        assertEquals("Toronto", reservations.get(0).getEventLocation());
+        assertEquals(EventService.STATUS_CANCELLED, reservations.get(1).getEventStatus());
+        verify(userRepository, times(1)).findById(userId);
         verify(reservationRepository, times(1)).findByUser_Id(userId);
     }
 
@@ -135,5 +158,61 @@ class ReservationServiceTest {
                 () -> reservationService.createReservation(request));
         assertEquals("Only 1 spots are available for this event.", error.getMessage());
         verify(reservationRepository, never()).save(any(Reservation.class));
+    }
+
+    @Test
+    void shouldRejectReservationWhenEventIsCancelled() {
+        Long userId = 10L;
+        Long eventId = 20L;
+        ReservationRequest request = new ReservationRequest(userId, eventId, 1);
+
+        User user = new User();
+        user.setId(userId);
+        user.setEmail("test@example.com");
+
+        Event event = new Event();
+        event.setEventId(eventId);
+        event.setTitle("Movie Night");
+        event.setStatus(EventService.STATUS_CANCELLED);
+
+        when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
+        when(eventRepository.findById(eventId)).thenReturn(java.util.Optional.of(event));
+
+        BadRequestException error = assertThrows(BadRequestException.class,
+                () -> reservationService.createReservation(request));
+        assertEquals("This event has been cancelled.", error.getMessage());
+        verify(reservationRepository, never()).save(any(Reservation.class));
+    }
+
+    @Test
+    void shouldCancelReservationForUser() {
+        Long userId = 10L;
+        Long reservationId = 99L;
+
+        User user = new User();
+        user.setId(userId);
+        user.setEmail("test@example.com");
+
+        Event event = new Event();
+        event.setEventId(20L);
+        event.setTitle("Movie Night");
+        event.setEventDate(LocalDate.of(2026, 5, 1));
+        event.setLocation("Montreal");
+        event.setStatus(EventService.STATUS_CANCELLED);
+
+        Reservation reservation = new Reservation(user, event, 2);
+        reservation.setId(reservationId);
+
+        when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
+        when(reservationRepository.findByIdAndUser_Id(reservationId, userId))
+                .thenReturn(java.util.Optional.of(reservation));
+
+        ReservationResponse response = reservationService.cancelReservation(userId, reservationId);
+
+        assertEquals(reservationId, response.getReservationId());
+        assertEquals("Reservation canceled successfully.", response.getMessage());
+        assertEquals("Movie Night", response.getEventName());
+        assertEquals(EventService.STATUS_CANCELLED, response.getEventStatus());
+        verify(reservationRepository, times(1)).delete(reservation);
     }
 }

--- a/client/app/src/main/AndroidManifest.xml
+++ b/client/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         <activity android:name=".SignInActivity" />
         <activity android:name=".SignUpActivity" />
         <activity android:name=".LoggedInActivity" />
+        <activity android:name=".MyReservationsActivity" />
         <activity android:name=".EventDetailsActivity" />
         <activity android:name=".HostDashboardActivity" />
         <activity android:name=".MainActivity" />

--- a/client/app/src/main/java/com/example/spareseat/CustomerNavigationHelper.java
+++ b/client/app/src/main/java/com/example/spareseat/CustomerNavigationHelper.java
@@ -1,0 +1,41 @@
+package com.example.spareseat;
+
+import android.content.Intent;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
+public final class CustomerNavigationHelper {
+
+    private CustomerNavigationHelper() {
+    }
+
+    public static void setup(AppCompatActivity activity,
+                             BottomNavigationView bottomNavigationView,
+                             int selectedItemId) {
+        syncSelection(bottomNavigationView, selectedItemId);
+        bottomNavigationView.setOnItemSelectedListener(item -> {
+            if (item.getItemId() == selectedItemId) {
+                return true;
+            }
+
+            Intent intent;
+            if (item.getItemId() == R.id.navBrowse) {
+                intent = new Intent(activity, LoggedInActivity.class);
+            } else if (item.getItemId() == R.id.navReservations) {
+                intent = new Intent(activity, MyReservationsActivity.class);
+            } else {
+                return false;
+            }
+
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            activity.startActivity(intent);
+            return true;
+        });
+    }
+
+    public static void syncSelection(BottomNavigationView bottomNavigationView, int selectedItemId) {
+        bottomNavigationView.setSelectedItemId(selectedItemId);
+    }
+}

--- a/client/app/src/main/java/com/example/spareseat/EventDetailsActivity.java
+++ b/client/app/src/main/java/com/example/spareseat/EventDetailsActivity.java
@@ -31,10 +31,12 @@ import retrofit2.Response;
 
 public class EventDetailsActivity extends AppCompatActivity {
     public static final String EXTRA_EVENT = "extra_event";
+    private static final String STATUS_CANCELLED = "CANCELLED";
 
     private EventResponse event;
     private TextView tvTitle;
     private TextView tvCategory;
+    private TextView tvEventStatus;
     private TextView tvDate;
     private TextView tvLocation;
     private TextView tvDescription;
@@ -69,12 +71,13 @@ public class EventDetailsActivity extends AppCompatActivity {
             return;
         }
 
+        isHostUser = "HOST".equals(SessionManager.getUserRole(this));
+
         swipeRefreshEventDetails.setColorSchemeColors(Color.parseColor("#89F336"));
         swipeRefreshEventDetails.setOnRefreshListener(() -> refreshEvent(false));
 
         populateEvent();
 
-        isHostUser = "HOST".equals(SessionManager.getUserRole(this));
         if (isHostUser) {
             llReservationSection.setVisibility(View.GONE);
             return;
@@ -86,6 +89,7 @@ public class EventDetailsActivity extends AppCompatActivity {
     private void bindViews() {
         tvTitle = findViewById(R.id.tvEventTitle);
         tvCategory = findViewById(R.id.tvEventCategory);
+        tvEventStatus = findViewById(R.id.tvEventStatus);
         tvDate = findViewById(R.id.tvEventDate);
         tvLocation = findViewById(R.id.tvEventLocation);
         tvDescription = findViewById(R.id.tvEventDescription);
@@ -122,6 +126,7 @@ public class EventDetailsActivity extends AppCompatActivity {
         tvLocation.setText(valueOrFallback(event.getLocation(), "Location to be announced"));
         tvDescription.setText(valueOrFallback(event.getDescription(), "No description available."));
 
+        updateEventStatusViews();
         updateCapacityLabel();
     }
 
@@ -132,6 +137,7 @@ public class EventDetailsActivity extends AppCompatActivity {
         tvLocation.setText("Location to be announced");
         tvDescription.setText("We couldn't load this event. Please go back and try again.");
         tvCapacity.setText("Capacity unavailable");
+        tvEventStatus.setVisibility(View.GONE);
         llReservationSection.setVisibility(View.GONE);
     }
 
@@ -282,15 +288,41 @@ public class EventDetailsActivity extends AppCompatActivity {
     }
 
     private void updateCapacityLabel() {
+        boolean isCancelled = STATUS_CANCELLED.equalsIgnoreCase(event.getStatus());
+        if (isCancelled) {
+            tvCapacity.setText("Event cancelled");
+            tvCapacity.setTextColor(getColor(R.color.danger));
+            if (!isHostUser) {
+                etQuantity.setEnabled(false);
+                btnReserve.setEnabled(false);
+                btnReserve.setText("Event Cancelled");
+                showStatus("This event has been cancelled.", false);
+            }
+            return;
+        }
+
+        etQuantity.setEnabled(true);
         int remainingSpots = event.getRemainingSpots();
         tvCapacity.setText(remainingSpots > 0
                 ? remainingSpots + " spots available"
                 : "Sold out");
+        tvCapacity.setTextColor(getColor(remainingSpots > 0 ? R.color.available_green : R.color.text_muted));
         btnReserve.setEnabled(remainingSpots > 0);
         if (remainingSpots <= 0) {
             btnReserve.setText("Event Sold Out");
         } else {
             btnReserve.setText("Sign Up For Event");
+            if (!isHostUser) {
+                hideStatus();
+            }
+        }
+    }
+
+    private void updateEventStatusViews() {
+        boolean isCancelled = STATUS_CANCELLED.equalsIgnoreCase(event.getStatus());
+        tvEventStatus.setVisibility(isCancelled ? View.VISIBLE : View.GONE);
+        if (isCancelled) {
+            tvEventStatus.setText("Cancelled");
         }
     }
 }

--- a/client/app/src/main/java/com/example/spareseat/HostDashboardActivity.java
+++ b/client/app/src/main/java/com/example/spareseat/HostDashboardActivity.java
@@ -74,6 +74,11 @@ public class HostDashboardActivity extends AppCompatActivity {
             public void onDelete(EventResponse event) {
                 confirmDelete(event);
             }
+
+            @Override
+            public void onCancel(EventResponse event) {
+                confirmCancel(event);
+            }
         });
 
         rvHostEvents.setLayoutManager(new LinearLayoutManager(this));
@@ -223,12 +228,9 @@ public class HostDashboardActivity extends AppCompatActivity {
             @Override
             public void onResponse(Call<EventResponse> call, Response<EventResponse> response) {
                 btnSave.setEnabled(true);
-                if (response.isSuccessful() && response.body() != null) {
-                    events.add(0, response.body());
-                    adapter.notifyItemInserted(0);
-                    rvHostEvents.scrollToPosition(0);
-                    updateListVisibility();
+                if (response.isSuccessful()) {
                     dialog.dismiss();
+                    fetchMyEvents();
                     Toast.makeText(HostDashboardActivity.this, "Event created!", Toast.LENGTH_SHORT).show();
                 } else {
                     Toast.makeText(HostDashboardActivity.this, "Failed to create event.", Toast.LENGTH_SHORT).show();
@@ -250,13 +252,9 @@ public class HostDashboardActivity extends AppCompatActivity {
             @Override
             public void onResponse(Call<EventResponse> call, Response<EventResponse> response) {
                 btnSave.setEnabled(true);
-                if (response.isSuccessful() && response.body() != null) {
-                    int index = indexById(eventId);
-                    if (index != -1) {
-                        events.set(index, response.body());
-                        adapter.notifyItemChanged(index);
-                    }
+                if (response.isSuccessful()) {
                     dialog.dismiss();
+                    fetchMyEvents();
                     Toast.makeText(HostDashboardActivity.this, "Event updated!", Toast.LENGTH_SHORT).show();
                 } else {
                     Toast.makeText(HostDashboardActivity.this, "Failed to update event.", Toast.LENGTH_SHORT).show();
@@ -280,6 +278,34 @@ public class HostDashboardActivity extends AppCompatActivity {
                 .setPositiveButton("Delete", (d, w) -> submitDelete(event))
                 .setNegativeButton("Cancel", null)
                 .show();
+    }
+
+    private void confirmCancel(EventResponse event) {
+        new AlertDialog.Builder(this)
+                .setTitle("Cancel Event")
+                .setMessage("Cancel \"" + event.getTitle() + "\"? Customers with reservations will still see it as cancelled.")
+                .setPositiveButton("Cancel Event", (d, w) -> submitCancel(event))
+                .setNegativeButton("Keep Event", null)
+                .show();
+    }
+
+    private void submitCancel(EventResponse event) {
+        ApiClient.getService().cancelEvent(event.getEventId()).enqueue(new Callback<EventResponse>() {
+            @Override
+            public void onResponse(Call<EventResponse> call, Response<EventResponse> response) {
+                if (response.isSuccessful()) {
+                    fetchMyEvents();
+                    Toast.makeText(HostDashboardActivity.this, "Event cancelled.", Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(HostDashboardActivity.this, "Failed to cancel event.", Toast.LENGTH_SHORT).show();
+                }
+            }
+
+            @Override
+            public void onFailure(Call<EventResponse> call, Throwable t) {
+                Toast.makeText(HostDashboardActivity.this, "Connection error.", Toast.LENGTH_SHORT).show();
+            }
+        });
     }
 
     private void submitDelete(EventResponse event) {
@@ -316,19 +342,24 @@ public class HostDashboardActivity extends AppCompatActivity {
     }
 
     private void updateListVisibility() {
+        updateEventCountLabel();
         if (events.isEmpty()) {
             showEmpty("No events yet. Create your first one!");
         } else {
-            tvEventCount.setText("My Events (" + events.size() + ")");
             rvHostEvents.setVisibility(View.VISIBLE);
             llEmpty.setVisibility(View.GONE);
         }
     }
 
     private void showEmpty(String message) {
+        updateEventCountLabel();
         tvEmpty.setText(message);
         llEmpty.setVisibility(View.VISIBLE);
         rvHostEvents.setVisibility(View.GONE);
+    }
+
+    private void updateEventCountLabel() {
+        tvEventCount.setText("My Events (" + events.size() + ")");
     }
 
     public static boolean isValidDateFormat(String date) {

--- a/client/app/src/main/java/com/example/spareseat/HostEventAdapter.java
+++ b/client/app/src/main/java/com/example/spareseat/HostEventAdapter.java
@@ -11,14 +11,17 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.spareseat.model.EventResponse;
+import com.google.android.material.button.MaterialButton;
 
 import java.util.List;
 
 public class HostEventAdapter extends RecyclerView.Adapter<HostEventAdapter.HostEventViewHolder> {
+    private static final String STATUS_CANCELLED = "CANCELLED";
 
     interface MenuClickListener {
         void onEdit(EventResponse event);
         void onDelete(EventResponse event);
+        void onCancel(EventResponse event);
     }
 
     private final List<EventResponse> events;
@@ -54,9 +57,22 @@ public class HostEventAdapter extends RecyclerView.Adapter<HostEventAdapter.Host
                 ? event.getDescription() : "No description available.");
 
         int remainingSpots = event.getRemainingSpots();
-        holder.tvCapacity.setText(remainingSpots > 0
-                ? remainingSpots + " spots available"
-                : "Sold out");
+        boolean isCancelled = STATUS_CANCELLED.equalsIgnoreCase(event.getStatus());
+        if (isCancelled) {
+            holder.tvCapacity.setText("Status: Cancelled");
+            holder.tvCapacity.setTextColor(holder.itemView.getContext().getColor(R.color.danger));
+        } else {
+            holder.tvCapacity.setText(remainingSpots > 0
+                    ? remainingSpots + " spots available"
+                    : "Sold out");
+            holder.tvCapacity.setTextColor(holder.itemView.getContext().getColor(
+                    remainingSpots > 0 ? R.color.available_green : R.color.text_muted
+            ));
+        }
+
+        holder.btnCancelEvent.setEnabled(!isCancelled);
+        holder.btnCancelEvent.setText(isCancelled ? "Cancelled" : "Cancel Event");
+        holder.btnCancelEvent.setOnClickListener(v -> listener.onCancel(event));
 
         holder.btnMenu.setOnClickListener(v -> {
             PopupMenu popup = new PopupMenu(v.getContext(), v);
@@ -82,6 +98,7 @@ public class HostEventAdapter extends RecyclerView.Adapter<HostEventAdapter.Host
     static class HostEventViewHolder extends RecyclerView.ViewHolder {
         final TextView tvTitle, tvCategory, tvDate, tvLocation, tvDescription, tvCapacity;
         final ImageButton btnMenu;
+        final MaterialButton btnCancelEvent;
 
         HostEventViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -92,6 +109,7 @@ public class HostEventAdapter extends RecyclerView.Adapter<HostEventAdapter.Host
             tvDescription = itemView.findViewById(R.id.tvDescription);
             tvCapacity    = itemView.findViewById(R.id.tvCapacity);
             btnMenu       = itemView.findViewById(R.id.btnMenu);
+            btnCancelEvent = itemView.findViewById(R.id.btnCancelEvent);
         }
     }
 }

--- a/client/app/src/main/java/com/example/spareseat/LoggedInActivity.java
+++ b/client/app/src/main/java/com/example/spareseat/LoggedInActivity.java
@@ -22,6 +22,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.example.spareseat.api.ApiClient;
 import com.example.spareseat.api.ApiService;
 import com.example.spareseat.model.EventResponse;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.textfield.TextInputEditText;
 
 import java.text.ParseException;
@@ -48,6 +49,7 @@ public class LoggedInActivity extends AppCompatActivity {
     private ProgressBar progressBar;
     private SwipeRefreshLayout swipeRefreshEvents;
     private AutoCompleteTextView actvLocation, actvCategory, actvDate;
+    private BottomNavigationView bottomNavigationView;
 
     private final List<EventResponse> allEvents = new ArrayList<>();
     private final List<EventResponse> filteredEvents = new ArrayList<>();
@@ -88,9 +90,11 @@ public class LoggedInActivity extends AppCompatActivity {
         actvLocation = findViewById(R.id.actvLocation);
         actvCategory = findViewById(R.id.actvCategory);
         actvDate     = findViewById(R.id.actvDate);
+        bottomNavigationView = findViewById(R.id.bottomNavigation);
 
         swipeRefreshEvents.setColorSchemeColors(Color.parseColor("#89F336"));
         swipeRefreshEvents.setOnRefreshListener(() -> fetchEvents(false, false));
+        CustomerNavigationHelper.setup(this, bottomNavigationView, R.id.navBrowse);
 
         // RecyclerView
         rvEvents.setLayoutManager(new LinearLayoutManager(this));
@@ -128,6 +132,7 @@ public class LoggedInActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        CustomerNavigationHelper.syncSelection(bottomNavigationView, R.id.navBrowse);
         fetchEvents(allEvents.isEmpty(), false);
     }
 

--- a/client/app/src/main/java/com/example/spareseat/MyReservationsActivity.java
+++ b/client/app/src/main/java/com/example/spareseat/MyReservationsActivity.java
@@ -1,0 +1,257 @@
+package com.example.spareseat;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+import com.example.spareseat.api.ApiClient;
+import com.example.spareseat.model.ReservationResponse;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class MyReservationsActivity extends AppCompatActivity {
+
+    private RecyclerView rvReservations;
+    private ReservationAdapter reservationAdapter;
+    private TextView tvReservationCount;
+    private TextView tvEmpty;
+    private LinearLayout llEmpty;
+    private ProgressBar progressBar;
+    private SwipeRefreshLayout swipeRefreshReservations;
+    private BottomNavigationView bottomNavigationView;
+
+    private final List<ReservationResponse> reservations = new ArrayList<>();
+    private final Set<Long> cancellingReservationIds = new HashSet<>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_my_reservations);
+
+        TextView tvSubtitle = findViewById(R.id.tvSubtitle);
+        String name = SessionManager.getUserName(this);
+        if (!TextUtils.isEmpty(name)) {
+            tvSubtitle.setText(name + ", you can manage your reservations here.");
+        }
+
+        Button btnLogout = findViewById(R.id.btnLogout);
+        btnLogout.setOnClickListener(v -> {
+            SessionManager.clear(this);
+            Intent intent = new Intent(this, WelcomeActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            startActivity(intent);
+        });
+
+        rvReservations = findViewById(R.id.rvReservations);
+        tvReservationCount = findViewById(R.id.tvReservationCount);
+        tvEmpty = findViewById(R.id.tvEmpty);
+        llEmpty = findViewById(R.id.llEmpty);
+        progressBar = findViewById(R.id.progressBar);
+        swipeRefreshReservations = findViewById(R.id.swipeRefreshReservations);
+        bottomNavigationView = findViewById(R.id.bottomNavigation);
+
+        swipeRefreshReservations.setColorSchemeColors(getColor(R.color.brand_lime));
+        swipeRefreshReservations.setOnRefreshListener(() -> fetchReservations(false, true));
+        CustomerNavigationHelper.setup(this, bottomNavigationView, R.id.navReservations);
+
+        rvReservations.setLayoutManager(new LinearLayoutManager(this));
+        reservationAdapter = new ReservationAdapter(reservations, cancellingReservationIds, this::confirmCancellation);
+        rvReservations.setAdapter(reservationAdapter);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        CustomerNavigationHelper.syncSelection(bottomNavigationView, R.id.navReservations);
+        fetchReservations(reservations.isEmpty(), false);
+    }
+
+    private void fetchReservations(boolean showFullScreenLoading, boolean showRefreshIndicator) {
+        long userId = SessionManager.getUserId(this);
+        if (userId == -1L) {
+            showEmptyState("Please sign in again to see your reservations.");
+            return;
+        }
+
+        if (showFullScreenLoading) {
+            progressBar.setVisibility(View.VISIBLE);
+            rvReservations.setVisibility(View.GONE);
+            llEmpty.setVisibility(View.GONE);
+        } else if (showRefreshIndicator && !swipeRefreshReservations.isRefreshing()) {
+            swipeRefreshReservations.setRefreshing(true);
+        }
+
+        ApiClient.getService().getReservationsForUser(userId).enqueue(new Callback<List<ReservationResponse>>() {
+            @Override
+            public void onResponse(Call<List<ReservationResponse>> call,
+                                   Response<List<ReservationResponse>> response) {
+                progressBar.setVisibility(View.GONE);
+                swipeRefreshReservations.setRefreshing(false);
+                if (response.isSuccessful() && response.body() != null) {
+                    reservations.clear();
+                    reservations.addAll(response.body());
+                    cancellingReservationIds.clear();
+                    reservationAdapter.notifyDataSetChanged();
+                    updateListVisibility();
+                } else if (reservations.isEmpty()) {
+                    showEmptyState("We couldn't load your reservations right now.");
+                } else {
+                    Toast.makeText(MyReservationsActivity.this,
+                            "Could not refresh reservations right now.",
+                            Toast.LENGTH_SHORT).show();
+                }
+            }
+
+            @Override
+            public void onFailure(Call<List<ReservationResponse>> call, Throwable t) {
+                progressBar.setVisibility(View.GONE);
+                swipeRefreshReservations.setRefreshing(false);
+                if (reservations.isEmpty()) {
+                    showEmptyState("Unable to connect. Check your internet connection.");
+                } else {
+                    Toast.makeText(MyReservationsActivity.this,
+                            "Refresh failed. Check your connection.",
+                            Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
+    }
+
+    private void confirmCancellation(ReservationResponse reservation) {
+        Long reservationId = reservation.getReservationId();
+        if (reservationId == null || cancellingReservationIds.contains(reservationId)) {
+            return;
+        }
+
+        String eventName = !TextUtils.isEmpty(reservation.getEventName())
+                ? reservation.getEventName()
+                : "this event";
+
+        new AlertDialog.Builder(this)
+                .setTitle("Cancel reservation?")
+                .setMessage("You'll give up your reserved spot" +
+                        (reservation.getQuantity() > 1 ? "s" : "") +
+                        " for " + eventName + ".")
+                .setNegativeButton("Keep", null)
+                .setPositiveButton("Cancel reservation", (dialog, which) -> cancelReservation(reservation))
+                .show();
+    }
+
+    private void cancelReservation(ReservationResponse reservation) {
+        Long reservationId = reservation.getReservationId();
+        long userId = SessionManager.getUserId(this);
+        if (reservationId == null || userId == -1L) {
+            Toast.makeText(this, "Please sign in again to cancel this reservation.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        cancellingReservationIds.add(reservationId);
+        reservationAdapter.notifyDataSetChanged();
+
+        ApiClient.getService().cancelReservation(reservationId, userId).enqueue(new Callback<ReservationResponse>() {
+            @Override
+            public void onResponse(Call<ReservationResponse> call, Response<ReservationResponse> response) {
+                cancellingReservationIds.remove(reservationId);
+                if (response.isSuccessful()) {
+                    removeReservation(reservationId);
+                    reservationAdapter.notifyDataSetChanged();
+                    updateListVisibility();
+
+                    String message = response.body() != null && !TextUtils.isEmpty(response.body().getMessage())
+                            ? response.body().getMessage()
+                            : "Reservation canceled successfully.";
+                    Toast.makeText(MyReservationsActivity.this, message, Toast.LENGTH_SHORT).show();
+                } else {
+                    reservationAdapter.notifyDataSetChanged();
+                    Toast.makeText(MyReservationsActivity.this,
+                            parseErrorBody(response, "We couldn't cancel that reservation."),
+                            Toast.LENGTH_SHORT).show();
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ReservationResponse> call, Throwable t) {
+                cancellingReservationIds.remove(reservationId);
+                reservationAdapter.notifyDataSetChanged();
+                Toast.makeText(MyReservationsActivity.this,
+                        "Unable to connect. Please check your internet connection.",
+                        Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void removeReservation(Long reservationId) {
+        for (int i = 0; i < reservations.size(); i++) {
+            if (reservationId.equals(reservations.get(i).getReservationId())) {
+                reservations.remove(i);
+                return;
+            }
+        }
+    }
+
+    private void updateListVisibility() {
+        int reservationCount = reservations.size();
+        tvReservationCount.setText(reservationCount == 0
+                ? "No reservations yet"
+                : reservationCount + (reservationCount == 1 ? " reservation" : " reservations"));
+
+        boolean isEmpty = reservations.isEmpty();
+        rvReservations.setVisibility(isEmpty ? View.GONE : View.VISIBLE);
+        llEmpty.setVisibility(isEmpty ? View.VISIBLE : View.GONE);
+        if (isEmpty) {
+            tvEmpty.setText("You haven't reserved a spot yet. Browse events and save a seat.");
+        }
+    }
+
+    private void showEmptyState(String message) {
+        tvReservationCount.setText("My reservations");
+        tvEmpty.setText(message);
+        progressBar.setVisibility(View.GONE);
+        rvReservations.setVisibility(View.GONE);
+        llEmpty.setVisibility(View.VISIBLE);
+    }
+
+    private String parseErrorBody(Response<?> response, String fallback) {
+        try {
+            if (response.errorBody() == null) {
+                return fallback;
+            }
+            String raw = response.errorBody().string();
+            if (TextUtils.isEmpty(raw)) {
+                return fallback;
+            }
+            JSONObject json = new JSONObject(raw);
+            if (json.has("message")) {
+                return json.getString("message");
+            }
+            if (json.has("error")) {
+                return json.getString("error");
+            }
+            return fallback;
+        } catch (Exception e) {
+            return fallback;
+        }
+    }
+}

--- a/client/app/src/main/java/com/example/spareseat/ReservationAdapter.java
+++ b/client/app/src/main/java/com/example/spareseat/ReservationAdapter.java
@@ -1,0 +1,101 @@
+package com.example.spareseat;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.spareseat.model.ReservationResponse;
+import com.google.android.material.button.MaterialButton;
+
+import java.util.List;
+import java.util.Set;
+
+public class ReservationAdapter extends RecyclerView.Adapter<ReservationAdapter.ReservationViewHolder> {
+    private static final String STATUS_CANCELLED = "CANCELLED";
+
+    interface OnCancelClickListener {
+        void onCancelClick(ReservationResponse reservation);
+    }
+
+    private final List<ReservationResponse> reservations;
+    private final Set<Long> cancellingReservationIds;
+    private final OnCancelClickListener listener;
+
+    public ReservationAdapter(List<ReservationResponse> reservations,
+                              Set<Long> cancellingReservationIds,
+                              OnCancelClickListener listener) {
+        this.reservations = reservations;
+        this.cancellingReservationIds = cancellingReservationIds;
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public ReservationViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_reservation_card, parent, false);
+        return new ReservationViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ReservationViewHolder holder, int position) {
+        ReservationResponse reservation = reservations.get(position);
+        holder.tvTitle.setText(valueOrFallback(reservation.getEventName(), "Reserved Event"));
+        holder.tvDate.setText(valueOrFallback(reservation.getEventDate(), "Date to be announced"));
+        holder.tvLocation.setText(valueOrFallback(reservation.getEventLocation(), "Location to be announced"));
+        holder.tvQuantity.setText(reservation.getQuantity() + (reservation.getQuantity() == 1
+                ? " spot reserved"
+                : " spots reserved"));
+
+        Long reservationId = reservation.getReservationId();
+        holder.tvReservationMeta.setText(reservationId != null
+                ? "Reservation #" + reservationId
+                : "Reservation");
+        boolean isCancelledEvent = STATUS_CANCELLED.equalsIgnoreCase(reservation.getEventStatus());
+        holder.tvEventStatus.setVisibility(isCancelledEvent ? View.VISIBLE : View.GONE);
+        if (isCancelledEvent) {
+            holder.tvEventStatus.setText("Cancelled");
+        }
+
+        boolean isCancelling = reservationId != null && cancellingReservationIds.contains(reservationId);
+        holder.btnCancel.setEnabled(!isCancelling);
+        holder.btnCancel.setText(holder.itemView.getContext().getString(
+                isCancelling ? R.string.cancelling_reservation : R.string.cancel_reservation
+        ));
+        holder.btnCancel.setOnClickListener(v -> listener.onCancelClick(reservation));
+    }
+
+    @Override
+    public int getItemCount() {
+        return reservations.size();
+    }
+
+    private String valueOrFallback(String value, String fallback) {
+        return value == null || value.trim().isEmpty() ? fallback : value;
+    }
+
+    static class ReservationViewHolder extends RecyclerView.ViewHolder {
+        final TextView tvTitle;
+        final TextView tvDate;
+        final TextView tvLocation;
+        final TextView tvQuantity;
+        final TextView tvReservationMeta;
+        final TextView tvEventStatus;
+        final MaterialButton btnCancel;
+
+        ReservationViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvTitle = itemView.findViewById(R.id.tvReservationTitle);
+            tvDate = itemView.findViewById(R.id.tvReservationDate);
+            tvLocation = itemView.findViewById(R.id.tvReservationLocation);
+            tvQuantity = itemView.findViewById(R.id.tvReservationQuantity);
+            tvReservationMeta = itemView.findViewById(R.id.tvReservationMeta);
+            tvEventStatus = itemView.findViewById(R.id.tvReservationEventStatus);
+            btnCancel = itemView.findViewById(R.id.btnCancelReservation);
+        }
+    }
+}

--- a/client/app/src/main/java/com/example/spareseat/api/ApiService.java
+++ b/client/app/src/main/java/com/example/spareseat/api/ApiService.java
@@ -18,6 +18,7 @@ import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
 import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 public interface ApiService {
     @POST("api/users/login")
@@ -41,8 +42,18 @@ public interface ApiService {
     @POST("api/reservations")
     Call<ReservationResponse> createReservation(@Body ReservationRequest request);
 
+    @GET("api/reservations/user/{userId}")
+    Call<List<ReservationResponse>> getReservationsForUser(@Path("userId") long userId);
+
+    @DELETE("api/reservations/{reservationId}")
+    Call<ReservationResponse> cancelReservation(@Path("reservationId") long reservationId,
+                                                @Query("userId") long userId);
+
     @PUT("api/events/update/{id}")
     Call<EventResponse> updateEvent(@Path("id") long id, @Body EventCreateRequest request);
+
+    @PUT("api/events/cancel/{id}")
+    Call<EventResponse> cancelEvent(@Path("id") long id);
 
     @DELETE("api/events/delete/{id}")
     Call<Void> deleteEvent(@Path("id") long id);

--- a/client/app/src/main/java/com/example/spareseat/model/EventResponse.java
+++ b/client/app/src/main/java/com/example/spareseat/model/EventResponse.java
@@ -14,6 +14,7 @@ public class EventResponse implements Serializable {
     private int eventCapacity;
     private int remainingSpots;
     private String category;
+    private String status;
 
     public EventResponse() {
     }
@@ -21,6 +22,13 @@ public class EventResponse implements Serializable {
     public EventResponse(Long eventId, Long organizerId, String title, String description,
                          String date, String location, int eventCapacity, int remainingSpots,
                          String category) {
+        this(eventId, organizerId, title, description, date, location, eventCapacity, remainingSpots,
+                category, "ACTIVE");
+    }
+
+    public EventResponse(Long eventId, Long organizerId, String title, String description,
+                         String date, String location, int eventCapacity, int remainingSpots,
+                         String category, String status) {
         this.eventId = eventId;
         this.organizerId = organizerId;
         this.title = title;
@@ -30,6 +38,7 @@ public class EventResponse implements Serializable {
         this.eventCapacity = eventCapacity;
         this.remainingSpots = remainingSpots;
         this.category = category;
+        this.status = status;
     }
 
     public Long getEventId() { return eventId; }
@@ -41,4 +50,5 @@ public class EventResponse implements Serializable {
     public int getEventCapacity() { return eventCapacity; }
     public int getRemainingSpots() { return remainingSpots; }
     public String getCategory() { return category; }
+    public String getStatus() { return status; }
 }

--- a/client/app/src/main/java/com/example/spareseat/model/ReservationResponse.java
+++ b/client/app/src/main/java/com/example/spareseat/model/ReservationResponse.java
@@ -6,6 +6,10 @@ public class ReservationResponse {
     private String customerEmail;
     private String eventName;
     private int quantity;
+    private Long eventId;
+    private String eventDate;
+    private String eventLocation;
+    private String eventStatus;
 
     public Long getReservationId() {
         return reservationId;
@@ -25,5 +29,21 @@ public class ReservationResponse {
 
     public int getQuantity() {
         return quantity;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public String getEventDate() {
+        return eventDate;
+    }
+
+    public String getEventLocation() {
+        return eventLocation;
+    }
+
+    public String getEventStatus() {
+        return eventStatus;
     }
 }

--- a/client/app/src/main/res/color/customer_bottom_nav_colors.xml
+++ b/client/app/src/main/res/color/customer_bottom_nav_colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/text_primary" android:state_checked="true" />
+    <item android:color="@color/bottom_nav_inactive" />
+</selector>

--- a/client/app/src/main/res/drawable/bg_status_cancelled.xml
+++ b/client/app/src/main/res/drawable/bg_status_cancelled.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/danger_surface" />
+    <corners android:radius="999dp" />
+</shape>

--- a/client/app/src/main/res/layout/activity_event_details.xml
+++ b/client/app/src/main/res/layout/activity_event_details.xml
@@ -76,6 +76,20 @@
                     android:textStyle="bold" />
 
                 <TextView
+                    android:id="@+id/tvEventStatus"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:background="@drawable/bg_status_cancelled"
+                    android:paddingHorizontal="12dp"
+                    android:paddingVertical="6dp"
+                    android:text="Cancelled"
+                    android:textColor="@color/danger"
+                    android:textSize="11sp"
+                    android:textStyle="bold"
+                    android:visibility="gone" />
+
+                <TextView
                     android:id="@+id/tvEventTitle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/client/app/src/main/res/layout/activity_logged_in.xml
+++ b/client/app/src/main/res/layout/activity_logged_in.xml
@@ -305,4 +305,15 @@
         </FrameLayout>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottomNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        android:elevation="10dp"
+        app:itemIconTint="@color/customer_bottom_nav_colors"
+        app:itemTextColor="@color/customer_bottom_nav_colors"
+        app:labelVisibilityMode="labeled"
+        app:menu="@menu/customer_bottom_nav_menu" />
+
 </LinearLayout>

--- a/client/app/src/main/res/layout/activity_my_reservations.xml
+++ b/client/app/src/main/res/layout/activity_my_reservations.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#FFFFFF">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingHorizontal="20dp"
+        android:paddingTop="20dp"
+        android:paddingBottom="14dp"
+        android:gravity="center_vertical">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tvHeading"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="My Reservations"
+                android:textColor="@color/text_primary"
+                android:textSize="26sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvSubtitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="Manage your upcoming event spots."
+                android:textColor="@color/text_secondary"
+                android:textSize="13sp" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btnLogout"
+            android:layout_width="wrap_content"
+            android:layout_height="40dp"
+            android:text="Log Out"
+            android:textColor="@color/text_primary"
+            android:textSize="13sp"
+            android:textStyle="bold"
+            android:backgroundTint="@color/brand_lime"
+            android:stateListAnimator="@null"
+            android:paddingHorizontal="18dp"
+            app:cornerRadius="20dp" />
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#F0F0F0" />
+
+    <TextView
+        android:id="@+id/tvReservationCount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Loading reservations..."
+        android:textColor="#AAAAAA"
+        android:textSize="12sp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="14dp"
+        android:layout_marginBottom="2dp" />
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshReservations"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvReservations"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:paddingHorizontal="20dp"
+                android:paddingTop="12dp"
+                android:paddingBottom="24dp"
+                android:clipToPadding="false"
+                android:visibility="gone" />
+
+            <LinearLayout
+                android:id="@+id/llEmpty"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:paddingHorizontal="32dp"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/tvEmpty"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="No reservations yet"
+                    android:textColor="#AAAAAA"
+                    android:textAlignment="center"
+                    android:textSize="16sp" />
+            </LinearLayout>
+
+            <ProgressBar
+                android:id="@+id/progressBar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:indeterminateTint="@color/brand_lime" />
+        </FrameLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottomNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        android:elevation="10dp"
+        app:itemIconTint="@color/customer_bottom_nav_colors"
+        app:itemTextColor="@color/customer_bottom_nav_colors"
+        app:labelVisibilityMode="labeled"
+        app:menu="@menu/customer_bottom_nav_menu" />
+
+</LinearLayout>

--- a/client/app/src/main/res/layout/item_reservation_card.xml
+++ b/client/app/src/main/res/layout/item_reservation_card.xml
@@ -5,11 +5,11 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="14dp"
+    app:cardBackgroundColor="#FFFFFF"
     app:cardCornerRadius="18dp"
     app:cardElevation="2dp"
-    app:strokeColor="#EFEFEF"
-    app:strokeWidth="1dp"
-    app:cardBackgroundColor="#FFFFFF">
+    app:strokeColor="@color/border_subtle"
+    app:strokeWidth="1dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -17,128 +17,108 @@
         android:orientation="vertical"
         android:padding="18dp">
 
-        <!-- ── TOP ACCENT BAR ── -->
         <View
             android:layout_width="36dp"
             android:layout_height="4dp"
-            android:background="@drawable/bg_category_badge"
-            android:layout_marginBottom="12dp"/>
+            android:layout_marginBottom="12dp"
+            android:background="@drawable/bg_category_badge" />
 
-        <!-- ── TITLE + 3-DOT MENU ── -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center_vertical">
-
-            <TextView
-                android:id="@+id/tvTitle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Event Title"
-                android:textColor="#111111"
-                android:textSize="16sp"
-                android:textStyle="bold"
-                android:layout_marginEnd="8dp"/>
-
-            <TextView
-                android:id="@+id/tvCategory"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="General"
-                android:textColor="#111111"
-                android:textSize="11sp"
-                android:textStyle="bold"
-                android:paddingHorizontal="10dp"
-                android:paddingVertical="5dp"
-                android:background="@drawable/bg_category_badge"
-                android:layout_marginEnd="8dp"/>
-
-            <ImageButton
-                android:id="@+id/btnMenu"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:src="@drawable/ic_more_vert"
-                android:contentDescription="More options"/>
-        </LinearLayout>
-
-        <!-- ── DATE & LOCATION ── -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginTop="10dp">
-
-            <TextView
-                android:id="@+id/tvDate"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Date"
-                android:textColor="#555555"
-                android:textSize="12sp"/>
-
-            <TextView
-                android:id="@+id/tvLocation"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Location"
-                android:textColor="#555555"
-                android:textSize="12sp"
-                android:gravity="end"/>
-        </LinearLayout>
-
-        <!-- ── DIVIDER ── -->
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="#F2F2F2"
-            android:layout_marginVertical="12dp"/>
-
-        <!-- ── DESCRIPTION ── -->
-        <TextView
-            android:id="@+id/tvDescription"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Description"
-            android:textColor="#777777"
-            android:textSize="13sp"
-            android:lineSpacingMultiplier="1.4"
-            android:maxLines="2"
-            android:ellipsize="end"/>
-
-        <!-- ── CAPACITY ── -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
             android:gravity="center_vertical"
             android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/tvCapacity"
+                android:id="@+id/tvReservationTitle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="30 spots available"
-                android:textColor="#3DB000"
-                android:textSize="12sp"
-                android:textStyle="bold"/>
+                android:layout_marginEnd="10dp"
+                android:text="Event Title"
+                android:textColor="@color/text_primary"
+                android:textSize="16sp"
+                android:textStyle="bold" />
 
-            <View
+            <TextView
+                android:id="@+id/tvReservationQuantity"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_category_badge"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="5dp"
+                android:text="2 spots reserved"
+                android:textColor="@color/text_primary"
+                android:textSize="11sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tvReservationDate"
                 android:layout_width="0dp"
-                android:layout_height="1dp"
-                android:layout_weight="0"
-                android:alpha="0" />
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Date"
+                android:textColor="@color/text_secondary"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/tvReservationLocation"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="end"
+                android:text="Location"
+                android:textColor="@color/text_secondary"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginVertical="12dp"
+            android:background="#F2F2F2" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tvReservationMeta"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Reservation #1"
+                android:textColor="@color/text_muted"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/tvReservationEventStatus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
+                android:background="@drawable/bg_status_cancelled"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="5dp"
+                android:text="Cancelled"
+                android:textColor="@color/danger"
+                android:textSize="11sp"
+                android:textStyle="bold"
+                android:visibility="gone" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnCancelEvent"
+                android:id="@+id/btnCancelReservation"
                 android:layout_width="wrap_content"
                 android:layout_height="40dp"
-                android:text="Cancel Event"
+                android:text="@string/cancel_reservation"
                 android:textAllCaps="false"
                 android:textColor="@color/danger"
                 app:backgroundTint="@color/danger_surface"

--- a/client/app/src/main/res/menu/customer_bottom_nav_menu.xml
+++ b/client/app/src/main/res/menu/customer_bottom_nav_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/navBrowse"
+        android:icon="@android:drawable/ic_menu_search"
+        android:title="@string/nav_browse" />
+    <item
+        android:id="@+id/navReservations"
+        android:icon="@android:drawable/ic_menu_my_calendar"
+        android:title="@string/nav_my_reservations" />
+</menu>

--- a/client/app/src/main/res/values/colors.xml
+++ b/client/app/src/main/res/values/colors.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="brand_lime">#89F336</color>
+    <color name="text_primary">#111111</color>
+    <color name="text_secondary">#555555</color>
+    <color name="text_muted">#777777</color>
+    <color name="danger">#B3261E</color>
+    <color name="danger_surface">#FFF1F0</color>
+    <color name="available_green">#3DB000</color>
+    <color name="border_subtle">#EFEFEF</color>
+    <color name="bottom_nav_inactive">#8A8A8A</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/client/app/src/main/res/values/strings.xml
+++ b/client/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">Spareseat</string>
+    <string name="nav_browse">Browse</string>
+    <string name="nav_my_reservations">My Reservations</string>
+    <string name="cancel_reservation">Cancel Reservation</string>
+    <string name="cancelling_reservation">Cancelling...</string>
 </resources>


### PR DESCRIPTION
## Summary
Adds customer reservation management and host event cancellation, plus a few related dashboard/navigation fixes.

## Backend
Added endpoints:
- GET /api/reservations/user/{userId} to list a customer’s reservations
- DELETE /api/reservations/{reservationId}?userId={userId} to cancel a reservation
- PUT /api/events/cancel/{id} to soft-cancel an event

## Behavior changes:
- Cancelled events stay visible to hosts
- Cancelled events are hidden from customer browsing
- Customers who already reserved still see cancelled events in My Reservations
- New reservations are blocked for cancelled events

## Android
- Added My Reservations screen for customers
- Added customer bottom nav between browse and reservations
- Added host Cancel Event action on event cards
- Show cancelled status in host/customer UI
- Fixed refresh/count/dialog issues in host and customer flows