### PR TITLE
Add Integration Tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -77,6 +77,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>

--- a/backend/src/test/java/com/soen345/ticketreserve/integration/EventApiIntegrationTest.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/integration/EventApiIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.soen345.ticketreserve.integration;
+
+import com.soen345.ticketreserve.model.Event;
+import com.soen345.ticketreserve.model.User;
+import com.soen345.ticketreserve.service.EventService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class EventApiIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    void shouldCreateCancelAndHideCancelledEventFromBrowseList() throws Exception {
+        User organizer = createUser("Host User", "host@example.com", "5145550001", "Password1", "HOST");
+
+        mockMvc.perform(post("/api/events/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "organizerId": %d,
+                                  "title": "Jazz Night",
+                                  "description": "Live music downtown",
+                                  "date": "2026-05-16",
+                                  "location": "Montreal",
+                                  "category": "Music",
+                                  "eventCapacity": 30
+                                }
+                                """.formatted(organizer.getId())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("Jazz Night"))
+                .andExpect(jsonPath("$.status").value(EventService.STATUS_ACTIVE))
+                .andExpect(jsonPath("$.remainingSpots").value(30));
+
+        Event createdEvent = eventRepository.findByTitle("Jazz Night").orElseThrow();
+
+        mockMvc.perform(put("/api/events/cancel/{id}", createdEvent.getEventId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventId").value(createdEvent.getEventId()))
+                .andExpect(jsonPath("$.status").value(EventService.STATUS_CANCELLED));
+
+        mockMvc.perform(get("/api/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+
+        mockMvc.perform(get("/api/events/organizer/{organizerId}", organizer.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].eventId").value(createdEvent.getEventId()))
+                .andExpect(jsonPath("$[0].status").value(EventService.STATUS_CANCELLED));
+    }
+
+    @Test
+    void shouldDeleteEventAndItsReservations() throws Exception {
+        User organizer = createUser("Host User", "host@example.com", "5145550001", "Password1", "HOST");
+        User customer = createUser("Customer User", "customer@example.com", "5145550002", "Password1", "CUSTOMER");
+        Event event = createEvent(
+                organizer,
+                "Movie Night",
+                LocalDate.of(2026, 6, 1),
+                "Montreal",
+                "Movies",
+                12,
+                "Outdoor screening",
+                EventService.STATUS_ACTIVE
+        );
+
+        mockMvc.perform(post("/api/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": %d,
+                                  "eventId": %d,
+                                  "quantity": 2
+                                }
+                                """.formatted(customer.getId(), event.getEventId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventName").value("Movie Night"))
+                .andExpect(jsonPath("$.quantity").value(2));
+
+        assertEquals(1, reservationRepository.count());
+
+        mockMvc.perform(delete("/api/events/delete/{id}", event.getEventId()))
+                .andExpect(status().isNoContent());
+
+        assertFalse(eventRepository.existsById(event.getEventId()));
+        assertEquals(0, reservationRepository.count());
+        assertTrue(userRepository.existsById(organizer.getId()));
+        assertTrue(userRepository.existsById(customer.getId()));
+    }
+}

--- a/backend/src/test/java/com/soen345/ticketreserve/integration/IntegrationTestSupport.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/integration/IntegrationTestSupport.java
@@ -1,0 +1,73 @@
+package com.soen345.ticketreserve.integration;
+
+import com.soen345.ticketreserve.model.Event;
+import com.soen345.ticketreserve.model.User;
+import com.soen345.ticketreserve.repository.EventRepository;
+import com.soen345.ticketreserve.repository.ReservationRepository;
+import com.soen345.ticketreserve.repository.UserRepository;
+import com.soen345.ticketreserve.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+abstract class IntegrationTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected UserRepository userRepository;
+
+    @Autowired
+    protected EventRepository eventRepository;
+
+    @Autowired
+    protected ReservationRepository reservationRepository;
+
+    @Autowired
+    protected PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    protected EmailService emailService;
+
+    @BeforeEach
+    void cleanDatabase() {
+        reservationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    protected User createUser(String name, String email, String phoneNumber, String password, String role) {
+        User user = new User();
+        user.setName(name);
+        user.setEmail(email);
+        user.setPhoneNumber(phoneNumber);
+        user.setPasswordHash(passwordEncoder.encode(password));
+        user.setRole(role);
+        return userRepository.save(user);
+    }
+
+    protected Event createEvent(User organizer, String title, LocalDate date, String location,
+                                String category, int eventCapacity, String description, String status) {
+        Event event = new Event();
+        event.setOrganizer(organizer);
+        event.setTitle(title);
+        event.setEventDate(date);
+        event.setLocation(location);
+        event.setCategory(category);
+        event.setEventCapacity(eventCapacity);
+        event.setDescription(description);
+        event.setStatus(status);
+        return eventRepository.save(event);
+    }
+}

--- a/backend/src/test/java/com/soen345/ticketreserve/integration/ReservationApiIntegrationTest.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/integration/ReservationApiIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.soen345.ticketreserve.integration;
+
+import com.soen345.ticketreserve.model.Event;
+import com.soen345.ticketreserve.model.User;
+import com.soen345.ticketreserve.service.EventService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReservationApiIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    void shouldCreateListAndCancelReservation() throws Exception {
+        User organizer = createUser("Host User", "host@example.com", "5145550001", "Password1", "HOST");
+        User customer = createUser("Customer User", "customer@example.com", "5145550002", "Password1", "CUSTOMER");
+        Event event = createEvent(
+                organizer,
+                "Tech Talk",
+                LocalDate.of(2026, 5, 20),
+                "Toronto",
+                "Tech",
+                10,
+                "Build systems at scale",
+                EventService.STATUS_ACTIVE
+        );
+
+        mockMvc.perform(post("/api/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": %d,
+                                  "eventId": %d,
+                                  "quantity": 2
+                                }
+                                """.formatted(customer.getId(), event.getEventId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customerEmail").value("customer@example.com"))
+                .andExpect(jsonPath("$.eventName").value("Tech Talk"))
+                .andExpect(jsonPath("$.quantity").value(2))
+                .andExpect(jsonPath("$.eventStatus").value(EventService.STATUS_ACTIVE));
+
+        Long reservationId = reservationRepository.findAll().get(0).getId();
+        verify(emailService).sendReservationConfirmation("customer@example.com", "Tech Talk", 2, reservationId);
+
+        mockMvc.perform(get("/api/events/{id}", event.getEventId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.remainingSpots").value(8));
+
+        mockMvc.perform(get("/api/reservations/user/{userId}", customer.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].eventName").value("Tech Talk"))
+                .andExpect(jsonPath("$[0].eventDate").value("2026-05-20"));
+
+        mockMvc.perform(delete("/api/reservations/{reservationId}", reservationId)
+                        .param("userId", customer.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reservationId").value(reservationId))
+                .andExpect(jsonPath("$.message").value("Reservation canceled successfully."));
+
+        assertEquals(0, reservationRepository.count());
+
+        mockMvc.perform(get("/api/reservations/user/{userId}", customer.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+
+        mockMvc.perform(get("/api/events/{id}", event.getEventId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.remainingSpots").value(10));
+    }
+
+    @Test
+    void shouldRejectReservationWhenCapacityWouldBeExceeded() throws Exception {
+        User organizer = createUser("Host User", "host@example.com", "5145550001", "Password1", "HOST");
+        User firstCustomer = createUser("Customer One", "one@example.com", "5145550002", "Password1", "CUSTOMER");
+        User secondCustomer = createUser("Customer Two", "two@example.com", "5145550003", "Password1", "CUSTOMER");
+        Event event = createEvent(
+                organizer,
+                "Workshop",
+                LocalDate.of(2026, 7, 10),
+                "Montreal",
+                "Learning",
+                3,
+                "Hands-on session",
+                EventService.STATUS_ACTIVE
+        );
+
+        mockMvc.perform(post("/api/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": %d,
+                                  "eventId": %d,
+                                  "quantity": 2
+                                }
+                                """.formatted(firstCustomer.getId(), event.getEventId())))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": %d,
+                                  "eventId": %d,
+                                  "quantity": 2
+                                }
+                                """.formatted(secondCustomer.getId(), event.getEventId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Only 1 spots are available for this event."));
+    }
+}

--- a/backend/src/test/java/com/soen345/ticketreserve/integration/UserApiIntegrationTest.java
+++ b/backend/src/test/java/com/soen345/ticketreserve/integration/UserApiIntegrationTest.java
@@ -1,0 +1,102 @@
+package com.soen345.ticketreserve.integration;
+
+import com.soen345.ticketreserve.model.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserApiIntegrationTest extends IntegrationTestSupport {
+
+    @Test
+    void shouldRegisterAndLoginCustomerWithEmail() throws Exception {
+        mockMvc.perform(post("/api/users/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "Alice",
+                                  "email": "alice@example.com",
+                                  "password": "Password1",
+                                  "role": "CUSTOMER"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Alice"))
+                .andExpect(jsonPath("$.email").value("alice@example.com"))
+                .andExpect(jsonPath("$.role").value("CUSTOMER"));
+
+        User savedUser = userRepository.findByEmail("alice@example.com").orElseThrow();
+        assertNotNull(savedUser.getId());
+        assertEquals("Alice", savedUser.getName());
+        assertTrue(passwordEncoder.matches("Password1", savedUser.getPasswordHash()));
+
+        mockMvc.perform(post("/api/users/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "alice@example.com",
+                                  "password": "Password1"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(savedUser.getId()))
+                .andExpect(jsonPath("$.email").value("alice@example.com"))
+                .andExpect(jsonPath("$.role").value("CUSTOMER"));
+    }
+
+    @Test
+    void shouldRejectDuplicateEmailRegistrationIgnoringCase() throws Exception {
+        createUser("Existing User", "taken@example.com", null, "Password1", "CUSTOMER");
+
+        mockMvc.perform(post("/api/users/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "Another User",
+                                  "email": "TAKEN@example.com",
+                                  "password": "Password1",
+                                  "role": "CUSTOMER"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Email is already registered"));
+    }
+
+    @Test
+    void shouldRegisterAndLoginHostWithPhoneNumber() throws Exception {
+        mockMvc.perform(post("/api/users/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "Morgan",
+                                  "phoneNumber": "5145551234",
+                                  "password": "Password1",
+                                  "role": "HOST"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Morgan"))
+                .andExpect(jsonPath("$.phoneNumber").value("5145551234"))
+                .andExpect(jsonPath("$.role").value("HOST"));
+
+        User savedUser = userRepository.findByPhoneNumber("5145551234").orElseThrow();
+
+        mockMvc.perform(post("/api/users/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "phoneNumber": "5145551234",
+                                  "password": "Password1"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(savedUser.getId()))
+                .andExpect(jsonPath("$.phoneNumber").value("5145551234"))
+                .andExpect(jsonPath("$.role").value("HOST"));
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,16 @@
+spring.datasource.url=jdbc:h2:mem:ticketreserve;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
+spring.jpa.open-in-view=false
+
+spring.mail.host=localhost
+spring.mail.port=2525
+
+debug=false
+logging.level.root=INFO


### PR DESCRIPTION
This PR adds real backend integration tests for the Spring Boot API. Instead of stopping at mocked controller/service tests, these new tests exercise the full flow through controllers, services, repositories, database persistence, and error handling.

What makes these full integration tests is that they boot the real Spring application context with SpringBootTest, send HTTP requests through MockMvc, use the actual service and repository beans, and persist data in a real test database via JPA. The only boundary still mocked is EmailService, so reservation tests don’t send real emails.

**What’s Included:**
- Added H2 as a test-only dependency in backend/pom.xml
- Added an isolated test profile in backend/src/test/resources/application-test.properties
- Added shared test setup in IntegrationTestSupport.java
- Added integration suites for:
- users: UserApiIntegrationTest.java
- events: EventApiIntegrationTest.java
- reservations: ReservationApiIntegrationTest.java

**Coverage Added:**
- register/login by email and phone
- duplicate registration rejection
- create/cancel/delete event flows
- public browse behavior for cancelled events
- create/list/cancel reservation flows
- capacity limit rejection
- reservation cleanup when an event is deleted

**Why:**
These tests give us confidence that the API works end to end with real JPA persistence, while staying isolated from the live Postgres and mail configuration.